### PR TITLE
Added scaladoc for various classes

### DIFF
--- a/core/src/main/scala/com/jaroop/play/sentry/AsyncAuth.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/AsyncAuth.scala
@@ -4,12 +4,33 @@ import javax.inject.Inject
 import play.api.mvc._
 import scala.concurrent.{ExecutionContext, Future}
 
+/**
+ *  Provides the ability to asychronously authenticate and authorize a logged-in user based on the contents of a request.
+ *  There should be little need to use this class directly, as its main purpose is to share code between the action builders.
+ *
+ *  @param config Requires an [[AuthConfig]] for authorization and user resolution.
+ *  @param idContainer Requires an [[IdContainer]] to validate the user's session and prolong it, if successful.
+ *  @param tokenAccessor Requires a [[TokenAccessor]] to retrieve an [[AuthenticityToken]] from the request,
+ *                       or to set a new one when prolonging the session timeout.
+ *
+ *  @tparam E The environment type.
+ */
 class AsyncAuth[E <: Env] @Inject() (
     config: AuthConfig[E],
     idContainer: IdContainer[E#Id],
     tokenAccessor: TokenAccessor
 ) {
 
+    /**
+     *  Restores a user from a request, and determines whether or not that user is authorized to perform an action identified
+     *  with a specific authority key.
+     *
+     *  @param authority The authority key with which to determine whether or not the user is authorized.
+     *  @param request The request used to identify a user by their cookies.
+     *  @return If the user is authorized for the given authority key, the logged-in user is returned tupled with a function
+     *          that will update a result with the user's new cookie (within an `ActionBuilder`).
+     *          If the user is not authorized, then the `Result` from [[AuthConfig#authorizationFailed]] will be returned.
+     */
     def authorized(authority: E#Authority)
         (implicit request: RequestHeader, ec: ExecutionContext): Future[Either[Result, (E#User, ResultUpdater)]] = {
         restoreUser collect {
@@ -26,6 +47,13 @@ class AsyncAuth[E <: Env] @Inject() (
         }
     }
 
+    /**
+     *  Authenticates a user from a request and prolongs their session if successful.
+     *
+     *  @param request The request used to identify a user by their cookies.
+     *  @return An optional user (`Some` if authentication is successful) tupled with a function that will update a result with
+     *          the user's new cookie (if they are actually logged-in, otherwise it does nothing).
+     */
     def restoreUser(implicit request: RequestHeader, ec: ExecutionContext): Future[(Option[E#User], ResultUpdater)] = {
         (for {
             token  <- extractToken(request)

--- a/core/src/main/scala/com/jaroop/play/sentry/AuthConfig.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/AuthConfig.scala
@@ -4,21 +4,85 @@ import play.api.mvc.{ RequestHeader, Result }
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.Duration
 
+/**
+ *  The [[AuthConfig]] defines the behavior of an application where it intersects with the authentication and authorization
+ *  system. This will allow Sentry to know how to find a user in your application, how to authorize them, and where to direct
+ *  them when these actions succeed or fail.
+ *
+ *  Most of the work involved in integrating Play Sentry into your application is implementing your own [[AuthConfig]]. Your own
+ *  [[AuthConfig]] should be a class that extends this type, fixes the `Env` type, and implements all of the methods to
+ *  customize it to your application's desired behavior.
+ *
+ *  @tparam E The environment type of your application.
+ */
 trait AuthConfig[E <: Env] {
 
+    /**
+     *  Defines the maximum lifespan of a session. Each session's timeout is reset to this value every time
+     *  a request from them is successfully authentiated.
+     */
     def sessionTimeout: Duration
 
+    /**
+     *  Resolves a user by ID. Implement this method to connect the user type from your own application.
+     *
+     *  @param id The ID of the user to find.
+     *  @return The user, if found, otherwise `None`.
+     */
     def resolveUser(id: E#Id)(implicit context: ExecutionContext): Future[Option[E#User]]
 
+    /**
+     *  Determines where to redirect the user by default after successfully logging in. Implement this method to specify
+     *  where to direct a user after `Login#gotoLoginSucceeded` is called.
+     *
+     *  @param request The original request used to authenticate.
+     *  @return A `Result` typically directing the user to a default URL to be seen after logging in, which will have
+     *          additional headers applied to set cookies on top of the provided `Result`.
+     */
     def loginSucceeded(request: RequestHeader)(implicit context: ExecutionContext): Future[Result]
 
+    /**
+     *  Determines where to redirect the user by default after logging out. Implement this method to specify where to direct
+     *  a user after `Logout#gotoLogoutSucceeded` is called.
+     *
+     *  @param request The request that initiated the logout action.
+     *  @return A `Result` typically directing the user to a default URL to be seen after logging out, which will additionally
+     *          contain headers to discard any Play Sentry cookies on top of the provided `Result`.
+     */
     def logoutSucceeded(request: RequestHeader)(implicit context: ExecutionContext): Future[Result]
 
+    /**
+     *  Called when a user attempts to access an action that requires authentication and they are not properly authenticated.
+     *  Implement this method to specify what happens when a user is not logged in. For example, return 403 Forbidden,
+     *  or redirect them to a login page.
+     *
+     *  @param request The unauthenticated request.
+     *  @return The `Result` you would like to return to the user when they are unauthenticated.
+     */
     def authenticationFailed(request: RequestHeader)(implicit context: ExecutionContext): Future[Result]
 
+    /**
+     *  Called when a user attempts to access an action that requires authorization, but they are not authorized via
+     *  [[AuthConfig#authorize]]. Implement this method to specify what happens when a user is not authorized to access
+     *  a resource. For example, return 403 Forbidden.
+     *
+     *  @param request The unauthorized request.
+     *  @param user The user that initiated the unauthorized request.
+     *  @param authority The authority key the user was denied from accessing.
+     *  @return The `Result` you would like to return to the user when they are unauthorized.
+     */
     def authorizationFailed(request: RequestHeader, user: E#User, authority: Option[E#Authority])
         (implicit context: ExecutionContext): Future[Result]
 
+    /**
+     *  Determines whether or not a user is authorized to perform a certain action by authority key. Implement this method
+     *  to connect your own authorization scheme from your application.
+     *
+     *  @param user The user requesting authorization to perform an action.
+     *  @param authority The authority key associated with the action.
+     *  @return True if the user is authorized, which will allow the action to proceed. Otherwise false, and the user will be
+     *          denied access and informed via [[AuthConfig#authorizationFailed]].
+     */
     def authorize(user: E#User, authority: E#Authority)(implicit context: ExecutionContext): Future[Boolean]
 
 }

--- a/core/src/main/scala/com/jaroop/play/sentry/AuthenticatedActionBuilder.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/AuthenticatedActionBuilder.scala
@@ -4,14 +4,55 @@ import javax.inject.Inject
 import play.api.mvc._
 import scala.concurrent.{ ExecutionContext, Future }
 
+/**
+ *  An authenticated request. It contains both the underlying Play request, and the logged-in user.
+ *
+ *  @param request The underlying request.
+ *  @param user The logged-in user that made the request.
+ *
+ *  @tparam A The type of the request body.
+ *  @tparam User The type of the user.
+ */
 class AuthRequest[A, User](request: Request[A], val user: User) extends WrappedRequest[A](request)
 
+/**
+ *  An `ActionBuilder` for endpoints where authentication or authorization is required.
+ *
+ *  This is one of the main components that will be used in an application. To use, you can simply just inject this component
+ *  into your controller with a specified [[Env]] type.
+ *
+ *  {{{
+ *      @Singleton
+ *      class HomeController @Inject() (
+ *          action: AuthenticatedActionBuilder[EnvImpl]
+ *      ) extends InjectedController {
+ *          def index = action { request =>
+ *              Ok(s"You are logged-in as ${request.user}!")
+ *          }
+ *      }
+ *  }}}
+ *
+ *  @param parser Uses the default `BodyParser`, but can be overridden with the `ActionBuilder` interface.
+ *  @param config Requires an [[AuthConfig]] for success and failure behavior for authentication.
+ *  @param auth Requires the [[AsyncAuth]] component for resolving a user and authorizing.
+ *
+ *  @tparam E The environment type of your application.
+ */
 class AuthenticatedActionBuilder[E <: Env] @Inject() (
     val parser: BodyParsers.Default,
     config: AuthConfig[E],
     auth: AsyncAuth[E]
 )(implicit val executionContext: ExecutionContext) extends ActionBuilder[AuthRequest[?, E#User], AnyContent] { self =>
 
+    /**
+     *  Creates an `ActionBuilder` with enforced authorization. First, it verifies that the user is authenticated, then it checks
+     *  whether or not the user is authorized against the given authority key.
+     *
+     *  @param authority The authority key the user should be authorized against.
+     *  @return An `ActionBuilder` whose invoke block will only be executed if the user is authenticated and authorized for
+     *          for the given authority key. If the user is not authorized, then they receive the `Result` as configured
+     *          by the available [[AuthConfig]].
+     */
     final def withAuthorization(authority: E#Authority): ActionBuilder[AuthRequest[?, E#User], AnyContent] = {
         new ActionBuilder[AuthRequest[?, E#User], AnyContent] {
             override def parser = self.parser
@@ -29,6 +70,18 @@ class AuthenticatedActionBuilder[E <: Env] @Inject() (
         }
     }
 
+    /**
+     *  The default implementation of an `ActionBuilder` with enforced authentication. It attempts to verify that the user is
+     *  logged-in based on the `Request`, and allows the action to proceed if they are. The body of the produced `Action`
+     *  accepts a `AuthRequest[A, User] => Future[Result]`, which will allow the action to access the user's details,
+     *  if needed.
+     *
+     *  @param request The incoming request from the user.
+     *  @param block A function to invoke if the user is authenticated. e.g. The body of a controller method.
+     *  @return If the user is authenticated, then the `Result` of the `block` function is returned, along with updated cookies
+     *          to prolong their session. If the user is not authenticated, then they receive the `Result` as configured by the
+     *          available [[AuthConfig]].
+     */
     override def invokeBlock[A](request: Request[A], block: AuthRequest[A, E#User] => Future[Result]): Future[Result] = {
         implicit val r = request
 

--- a/core/src/main/scala/com/jaroop/play/sentry/Env.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/Env.scala
@@ -1,11 +1,24 @@
 package com.jaroop.play.sentry
 
+/**
+ *  Defines the types that are implemented by client-code tied to user authentication and authorization. This provides
+ *  the freedom to use any type of user, user ID, or authority key, without needing those types to implement any
+ *  sort of interface to work. This type will allow you bundle up your type definitions into one place, and use it to
+ *  specify what types are needed to the Play Sentry components when they are injected.
+ */
 trait Env {
 
+    /** The type of the User's ID. For example: `Long`, `String`, etc. */
     type Id
 
+    /** The type of the authenticated user. Implement this as the user type in your application. */
     type User
 
+    /**
+     *  The type used as an authority key. That is, the type that encodes different levels of authorization.
+     *  Every `Action` that uses authorization must specify an authority key of this type. For example, this could be
+     *  a role, a group, or something else a user can be associated with.
+     */
     type Authority
 
 }

--- a/core/src/main/scala/com/jaroop/play/sentry/OptionalAuthenticatedActionBuilder.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/OptionalAuthenticatedActionBuilder.scala
@@ -4,13 +4,55 @@ import javax.inject.Inject
 import play.api.mvc._
 import scala.concurrent.{ ExecutionContext, Future }
 
+/**
+ *  An optionally authenticated request. It contains both the underlying Play request, and an optional logged-in user.
+ *  (If the user is authenticated.)
+ *
+ *  @param request The underlying request.
+ *  @param user The logged-in user that made the request, if they are authenticated. Otherwise, `None`.
+ *
+ *  @tparam A The type of the request body.
+ *  @tparam User The type of the user.
+ */
 class OptionalAuthRequest[A, User](request: Request[A], val user: Option[User]) extends WrappedRequest[A](request)
 
+/**
+ *  An `ActionBuilder` that can be used for actions where authentication is optional. The endpoints that use this action
+ *  will be publically accessible, but you may alter the behavior depending on whether or not a user is present.
+ *
+ *  To use, you can simply just inject this component into your controller with a specified [[Env]] type.
+ *
+ *  {{{
+ *      @Singleton
+ *      class HomeController @Inject() (
+ *          action: OptionalAuthenticatedActionBuilder[EnvImpl]
+ *      ) extends InjectedController {
+ *          def index = action { request =>
+ *              request.user match {
+ *                  case Some(user) => Ok(s"You are logged-in as ${user}!")
+ *                  case None => Ok("You are not logged-in, but you can view this page, anyway.")
+ *              }
+ *          }
+ *      }
+ *  }}}
+ *
+ *  @param parser Uses the default `BodyParser`, but can be overridden with the `ActionBuilder` interface.
+ *  @param auth Requires the [[AsyncAuth]] component for resolving a user.
+ *
+ *  @tparam E The environment type of your application.
+ */
 class OptionalAuthenticatedActionBuilder[E <: Env] @Inject() (
     val parser: BodyParsers.Default,
     auth: AsyncAuth[E]
 )(implicit val executionContext: ExecutionContext) extends ActionBuilder[OptionalAuthRequest[?, E#User], AnyContent] {
 
+    /**
+     *  Attempts to verify if the user is authenticated before invoking the `block` function.
+     *
+     *  @param request The incoming request from the user.
+     *  @param block A function to invoke. e.g. The body of a controller method.
+     *  @return Returns the result of the `block` function, with updated cookies if the user is authenticated.
+     */
     override def invokeBlock[A](request: Request[A], block: OptionalAuthRequest[A, E#User] => Future[Result]) = {
         implicit val r = request
         val maybeUserFuture = auth.restoreUser.recover { case _ => None -> identity[Result] _ }

--- a/core/src/main/scala/com/jaroop/play/sentry/package.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/package.scala
@@ -2,12 +2,16 @@ package com.jaroop.play
 
 import play.api.mvc.Result
 
+/** The Play Sentry API. */
 package object sentry {
 
+    /** Play Sentry tokens are generated as strings. */
     type AuthenticityToken = String
 
+    /** Signed Play Sentry tokens are strings. */
     type SignedToken = String
 
+    /** An alias to a function that updates a `Result` with a new `Result`. */
     type ResultUpdater = Result => Result
 
 }


### PR DESCRIPTION
This adds scaladoc for:
* The `sentry` package
* `AsyncAuth`
* `AuthRequest`
* `AuthenticatedActionBuilder`
* `AuthConfig`
* `Env`
* `OptionalAuthRequest`
* `OptionalAuthenticatedActionBuilder`

https://jaroop.atlassian.net/browse/JCOR-228
https://jaroop.atlassian.net/browse/JCOR-229
https://jaroop.atlassian.net/browse/JCOR-230
https://jaroop.atlassian.net/browse/JCOR-233
https://jaroop.atlassian.net/browse/JCOR-236
https://jaroop.atlassian.net/browse/JCOR-239

This should cover about half, so far. There will undoubtedly be grammatical errors. There are a few methods that could be using scaladoc links `[[ClassName#methodName]]`, but are ambiguous overloads and I gave up on trying to figure out the cryptic scaladoc rules to disambiguate them.