### PR TITLE
Added scaladoc for remaining classes

### DIFF
--- a/core/src/main/scala/com/jaroop/play/sentry/CookieTokenAccessor.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/CookieTokenAccessor.scala
@@ -5,6 +5,13 @@ import play.api.Configuration
 import play.api.libs.crypto.CookieSigner
 import play.api.mvc.{ DiscardingCookie, Cookie, Result, RequestHeader }
 
+/**
+ *  A [[TokenAccessor]] that stores [[SignedToken SignedTokens]] within cookies.
+ *
+ *  @param config An application configuration to supply custom settings for issued cookies, such as security settings,
+ *                expiration, domain, etc.
+ *  @param signer Requires a [[play.api.libs.crypto.CookieSigner CookieSigner]] to sign the tokens.
+ */
 class CookieTokenAccessor @Inject() (config: Configuration, val signer: CookieSigner) extends TokenAccessor {
 
     protected val name: String = config.getOptional[String]("sentry.cookie.name").getOrElse("SENTRY_SESS_ID")
@@ -19,15 +26,18 @@ class CookieTokenAccessor @Inject() (config: Configuration, val signer: CookieSi
 
     protected val maxAge: Option[Int] = config.getOptional[Int]("sentry.cookie.maxAge")
 
+    /** @inheritdoc */
     def put(token: AuthenticityToken)(result: Result)(implicit request: RequestHeader): Result = {
         val c = Cookie(name, sign(token), maxAge, path, domain, secure, httpOnly)
         result.withCookies(c)
     }
 
+    /** @inheritdoc */
     def extract(request: RequestHeader): Option[AuthenticityToken] = {
         request.cookies.get(name).flatMap(c => verifyHmac(c.value))
     }
 
+    /** @inheritdoc */
     def delete(result: Result)(implicit request: RequestHeader): Result = {
         result.discardingCookies(DiscardingCookie(name))
     }

--- a/core/src/main/scala/com/jaroop/play/sentry/IdContainer.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/IdContainer.scala
@@ -3,14 +3,58 @@ package com.jaroop.play.sentry
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration.Duration
 
+/**
+ *  An `IdContainer`'s job is to manage user sessions server-side. It is responsible for creating, destroying, validating,
+ *  and prolonging existing sessions.
+ *
+ *  The basic workflow is:
+ *
+ *  1.) A user ID is passed to start a new session, and the `IdContainer` gives the user an [[AuthenticityToken]] in return.
+ *  2.) The user presents the [[AuthenticityToken]] as evidence that they are authenticated, and the `IdContainer`
+ *      confirms the validity of the token.
+ *  3.) When presenting a valid [[AuthenticityToken]], that token's session can be prolonged.
+ *  4.) When the user logs out, the `IdContainer` will no longer recognize their token as valid.
+ *
+ *  @tparam Id The type of the user's ID, which is a primary identifier of a session.
+ */
 trait IdContainer[Id] {
 
+    /**
+     *  Opens a new session for a user, and generates an [[AuthenticityToken]] that is paired with that user's ID.
+     *
+     *  @param userId The ID of the session the session will be created for.
+     *  @param timeout How long the session will be valid before expiring in a stateful `IdContainer`.
+     *  @return An [[AuthenticityToken]] to be given to the user to later verify their session is valid.
+     */
     def startNewSession(userId: Id, timeout: Duration)(implicit ec: ExecutionContext): Future[AuthenticityToken]
 
+    /**
+     *  Destroys the session identified by a given token.
+     *
+     *  @param token The [[AuthenticityToken]] that is paired with the session to be destroyed.
+     *  @return A successful `Future` if the session was destroyed, or a failed `Future` if an error occurred.
+     */
     def remove(token: AuthenticityToken)(implicit ec: ExecutionContext): Future[Unit]
 
+    /**
+     *  Finds the user ID that is associated with an [[AuthenticityToken]]. If `Some[Id]` is returned, that is sufficient to
+     *  show that a user's session is valid.
+     *
+     *  @param token The [[AuthenticityToken]] to verify.
+     *  @return The user ID associated with the [[AuthenticityToken]] within the `IdContainer`, if there is one.
+     *          Otherwise, `None`.
+     */
     def get(token: AuthenticityToken)(implicit ec: ExecutionContext): Future[Option[Id]]
 
+    /**
+     *  Delays the expiration of a session by a given duration.
+     *
+     *  @param token The [[AuthenticityToken]] of the session to prolong.
+     *  @param timeout The new duration of the session. e.g. if there is 30 minutes left in a session, and a timeout of one hour
+     *                 is passed, the session will expire in one hour.
+     *  @return A successful `Future` if the session was prolonged, or a failed `Future` if the session isn't valid, or
+     *          some other error occurred.
+     */
     def prolongTimeout(token: AuthenticityToken, timeout: Duration)(implicit ec: ExecutionContext): Future[Unit]
 
 }

--- a/core/src/main/scala/com/jaroop/play/sentry/Login.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/Login.scala
@@ -4,16 +4,55 @@ import javax.inject.Inject
 import play.api.mvc.{ Cookie, RequestHeader, Result }
 import scala.concurrent.{ ExecutionContext, Future }
 
+/**
+ *  The `Login` component provides the user's first entry point into Play Sentry via your application.
+ *
+ *  It is up to your application to decide when a user is to be logged-in (i.e. provides the correct credentials to a login
+ *  form of some kind), and from there your controller can use this component to create a session for that user by their ID.
+ *  To use it, you simply inject `Login` into your controller, and call `gotoLoginSucceeded(userId)` when you want to grant
+ *  a session to a user linked to a particular `userId`.
+ *
+ *  {{{
+ *      @Singleton
+ *      class Application @Inject() (login: Login[MyEnv], userService: UserService) extends InjectedController {
+ *          def login = Action.async(parse.urlEncodedForm) { implicit request =>
+ *              // logic to determine to handle user name and password..
+ *              gotoLoginSucceeded(userId)
+ *          }
+ *      }
+ *  }}}
+ *
+ *  @param config Requires an [[AuthConfig]] to determine the default `Result` to return to the user once logged-in.
+ *  @param idContainer The [[IdContainer]] that will store the session server-side.
+ *  @param tokenAccessor The [[TokenAccessor]] that will store the session client-side.
+ *
+ *  @tparam E The environment type of your application.
+ */
 class Login[E <: Env] @Inject() (
     config: AuthConfig[E],
     idContainer: IdContainer[E#Id],
     tokenAccessor: TokenAccessor
 ) {
 
+    /**
+     *  Creates a new session for a user.
+     *
+     *  @param userId The ID of the user to grant the session to.
+     *  @return The default `Result` defined in the [[AuthConfig]] when the user is logged-in, with an [[AuthenticityToken]]
+     *          included.
+     */
     def gotoLoginSucceeded(userId: E#Id)(implicit request: RequestHeader, ctx: ExecutionContext): Future[Result] = {
         gotoLoginSucceeded(userId, config.loginSucceeded(request))
     }
 
+    /**
+     *  Creates a new session for a user, and allows a custom result (different than from the [[AuthConfig]]) to be returned
+     *  to them once the session has been created.
+     *
+     *  @param userId The ID of the user to grant the session to.
+     *  @param result The `Result` to return to the user once their session is created.
+     *  @return The given `Result` with an [[AuthenticityToken]] included.
+     */
     def gotoLoginSucceeded(userId: E#Id, result: => Future[Result])
         (implicit request: RequestHeader, ctx: ExecutionContext): Future[Result] = {
 

--- a/core/src/main/scala/com/jaroop/play/sentry/Logout.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/Logout.scala
@@ -4,16 +4,50 @@ import javax.inject.Inject
 import play.api.mvc.{ Cookie, RequestHeader, Result }
 import scala.concurrent.{ ExecutionContext, Future }
 
+/**
+ *  The `Logout` component provides the ability for a controller to destroy a logged-in user's session.
+ *
+ *  To use it, you simply inject `Logout` into your controller, and call `gotoLogoutSucceeded()` when you want the logged-in
+ *  user to be logged-out.
+ *
+ *  {{{
+ *      @Singleton
+ *      class Application @Inject() (logout: Logout[MyEnv]) extends InjectedController {
+ *          def logout = Action.async { implicit request =>
+ *              gotoLogoutSucceeded()
+ *          }
+ *      }
+ *  }}}
+ *
+ *  @param config Requires an [[AuthConfig]] to determine the default `Result` to return to the user once logged-out.
+ *  @param idContainer The [[IdContainer]] that will forget the session server-side.
+ *  @param tokenAccessor The [[TokenAccessor]] that will forget the session client-side.
+ *
+ *  @tparam E The environment type of your application.
+ */
 class Logout[E <: Env] @Inject() (
     config: AuthConfig[E],
     idContainer: IdContainer[E#Id],
     tokenAccessor: TokenAccessor
 ) {
 
+    /**
+     *  Destroys the session of the logged-in user that made a request, if any.
+     *
+     *  @return The default `Result` defined in the [[AuthConfig]] when the user is logged-out, with a header to discard
+     *          any Play Sentry cookies.
+     */
     def gotoLogoutSucceeded(implicit request: RequestHeader, ctx: ExecutionContext): Future[Result] = {
         gotoLogoutSucceeded(config.logoutSucceeded(request))
     }
 
+    /**
+     *  Destroys the session of the logged-in user that made a request, if any, and returns the given `Result` regardless of
+     *  success or failure.
+     *
+     *  @param result The `Result` to return the user once they are logged-out.
+     *  @return The given `Result` with a header to discard any Play Sentry cookies.
+     */
     def gotoLogoutSucceeded(result: => Future[Result])(implicit request: RequestHeader, ctx: ExecutionContext): Future[Result] = {
         tokenAccessor.extract(request) foreach idContainer.remove
         result.map(tokenAccessor.delete)

--- a/core/src/main/scala/com/jaroop/play/sentry/TokenAccessor.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/TokenAccessor.scala
@@ -3,21 +3,62 @@ package com.jaroop.play.sentry
 import play.api.mvc.{ RequestHeader, Result }
 import play.api.libs.crypto.CookieSigner
 
+/**
+ *  Provides an interface for managing sessions client-side via requests and results. A [[TokenAccessor]] should be able to add
+ *  or remove a [[SignedToken]] from a `Result`, as well as verify the signature of a [[SignedToken]] from a `RequestHeader`.
+ *
+ *  While it is not required to use them, token accessors should use the available signing methods in this trait to sign
+ *  and verify tokens so that they cannot be tampered with by an attacker.
+ */
 trait TokenAccessor {
 
+    /** Requires a `CookieSigner` to sign tokens and verify token signatures. */
     def signer: CookieSigner
 
+    /**
+     *  Attempts to extract an [[AuthenticityToken]] from a `RequestHeader`.
+     *
+     *  @param request The `RequestHeader` to extract the token from.
+     *  @return An [[AuthenticityToken]] if the request contains a token with a valid signature. Otherwise, `None`.
+     */
     def extract(request: RequestHeader): Option[AuthenticityToken]
 
+    /**
+     *  Puts an [[AuthenticityToken]] into a `Result` to return to a user.
+     *
+     *  @param token The [[AuthenticityToken]] to be issued to a user.
+     *  @return A `Result` containing a [[SignedToken]] or [[AuthenticityToken]].
+     */
     def put(token: AuthenticityToken)(result: Result)(implicit request: RequestHeader): Result
 
+    /**
+     *  Removes any issued [[AuthenticityToken]] or [[SignedToken]] from a `Result`.
+     *
+     *  @param result The `Result` to remove all issued tokens from.
+     *  @return A new `Result` without any issued tokens.
+     */
     def delete(result: Result)(implicit request: RequestHeader): Result
 
+    /**
+     *  Verifies that a [[SignedToken]] token is valid by comparing the stored signature in the [[SignedToken]] to the
+     *  signature of the raw [[AuthenticityToken]] that is part of the [[SignedToken]]. In order for ''any'' [[SignedToken]]
+     *  to be valid, it must be issued via the [[TokenAccessor#sign]] method.
+     *
+     *  @param token The [[SignedToken]] to validate.
+     *  @return The contained [[AuthenticityToken]] if the signature is valid, otherwise `None`.
+     */
     protected def verifyHmac(token: SignedToken): Option[AuthenticityToken] = {
         val (hmac, value) = token.splitAt(40)
         if (safeEquals(signer.sign(value), hmac)) Some(value) else None
     }
 
+    /**
+     *  Signs an [[AuthenticityToken]] and concatenates it with its signature. ("$${signature}$${token}") The resulting
+     *  [[SignedToken]] is meant to be issued to a user (e.g., within a cookie).
+     *
+     *  @param token The [[AuthenticityToken]] to sign.
+     *  @return The signature of the [[AuthenticityToken]] concatenated with the token itself.
+     */
     protected def sign(token: AuthenticityToken): SignedToken = signer.sign(token) + token
 
     // Do not change this unless you understand the security issues behind timing attacks.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")
+
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "latest.release")


### PR DESCRIPTION
This adds scaladoc for:
* `CacheIdContainer`
* `CookieTokenAccessor`
* `IdContainer`
* `Login`
* `Logout`
* `TokenAccessor`
* `TransparentIdContainer`

https://jaroop.atlassian.net/browse/JCOR-231
https://jaroop.atlassian.net/browse/JCOR-232
https://jaroop.atlassian.net/browse/JCOR-234
https://jaroop.atlassian.net/browse/JCOR-235
https://jaroop.atlassian.net/browse/JCOR-237
https://jaroop.atlassian.net/browse/JCOR-238
https://jaroop.atlassian.net/browse/JCOR-274