### PR TITLE
0.9.x test helpers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,21 @@ lazy val baseSettings = Seq(
   publishArtifact in Test := false,
   pomIncludeRepository := { _: MavenRepository => false },
   fork in Test := true,
-  parallelExecution in Test := false
+  parallelExecution in Test := false,
+  publishTo := Some(
+    if (isSnapshot.value)
+      Opts.resolver.sonatypeSnapshots
+    else
+      Opts.resolver.sonatypeStaging
+  ),
+  licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
+  homepage := Some(url("https://github.com/jaroop/play-sentry")),
+  scmInfo := Some(
+    ScmInfo(
+      url("https://github.com/jaroop/play-sentry"),
+      "scm:git@github.com:jaroop/play-sentry.git"
+    )
+  )
 )
 
 def scalacOptionsVersion(scalaVersion: String) = {

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@
 val appName = "play-sentry"
 
 val playVersion = play.core.PlayVersion.current
+val specsVersion = "3.9.5"
 
 lazy val baseSettings = Seq(
   version := "0.9.0-SNAPSHOT",
@@ -15,7 +16,9 @@ lazy val baseSettings = Seq(
   scalacOptions ++= scalacOptionsVersion(scalaVersion.value),
   publishMavenStyle := true,
   publishArtifact in Test := false,
-  pomIncludeRepository := { _: MavenRepository => false }
+  pomIncludeRepository := { _: MavenRepository => false },
+  fork in Test := true,
+  parallelExecution in Test := false
 )
 
 def scalacOptionsVersion(scalaVersion: String) = {
@@ -42,13 +45,27 @@ lazy val core = (project in file("core"))
       "com.typesafe.play" %% "play" % playVersion % "provided",
       "com.typesafe.play" %% "play-cache" % playVersion % "provided",
       "com.typesafe.play" %% "play-test" % playVersion % "test",
-      "org.specs2" %% "specs2-core" % "3.9.5" % "test",
-      "org.specs2" %% "specs2-mock" % "3.9.5" % "test"
+      "org.specs2" %% "specs2-core" % specsVersion % "test",
+      "org.specs2" %% "specs2-mock" % specsVersion % "test"
     ),
-    fork in Test := true,
-    parallelExecution in Test := false,
     addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.4" cross CrossVersion.binary)
   )
+
+lazy val sentryTest = (project in file("sentry-test"))
+  .settings(
+    name := appName + "-test",
+    baseSettings,
+    libraryDependencies ++= Seq(
+      "com.typesafe.play" %% "play" % playVersion % "provided",
+      "com.typesafe.play" %% "play-test" % playVersion % "provided",
+      "com.typesafe.play" %% "play-specs2" % playVersion % "test",
+      cache % "test",
+      "org.specs2" %% "specs2-core" % specsVersion % "test",
+      "org.specs2" %% "specs2-mock" % specsVersion % "test"
+    ),
+    addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.4" cross CrossVersion.binary)
+  ).dependsOn(core)
+
 
 lazy val examples = (project in file("examples"))
   .enablePlugins(PlayScala)
@@ -60,4 +77,4 @@ lazy val examples = (project in file("examples"))
   )
   .dependsOn(core)
 
-lazy val root = (project in file(".")).settings(baseSettings).aggregate(core)
+lazy val root = (project in file(".")).settings(baseSettings).aggregate(core, sentryTest)

--- a/build.sbt
+++ b/build.sbt
@@ -60,8 +60,8 @@ lazy val sentryTest = (project in file("sentry-test"))
       "com.typesafe.play" %% "play-test" % playVersion % "provided",
       "com.typesafe.play" %% "play-specs2" % playVersion % "test",
       cache % "test",
-      "org.specs2" %% "specs2-core" % specsVersion % "test",
-      "org.specs2" %% "specs2-mock" % specsVersion % "test"
+      "org.specs2" %% "specs2-core" % "3.6.6" % "test",
+      "org.specs2" %% "specs2-mock" % "3.6.6" % "test"
     ),
     addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.4" cross CrossVersion.binary)
   ).dependsOn(core)
@@ -72,9 +72,13 @@ lazy val examples = (project in file("examples"))
   .settings(
     baseSettings,
     libraryDependencies ++= Seq(
-      cache
+      cache,
+      "com.typesafe.play" %% "play-test" % playVersion % "provided",
+      "com.typesafe.play" %% "play-specs2" % playVersion % "test",
+      "org.specs2" %% "specs2-core" % "3.6.6" % "test",
+      "org.specs2" %% "specs2-mock" % "3.6.6" % "test"
     )
   )
-  .dependsOn(core)
+  .dependsOn(core, sentryTest)
 
 lazy val root = (project in file(".")).settings(baseSettings).aggregate(core, sentryTest)

--- a/core/src/main/scala/com/jaroop/play/sentry/AsyncAuth.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/AsyncAuth.scala
@@ -1,6 +1,7 @@
 package com.jaroop.play.sentry
 
 import javax.inject.Inject
+import play.api.Environment
 import play.api.mvc._
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -18,7 +19,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class AsyncAuth[E <: Env] @Inject() (
     config: AuthConfig[E],
     idContainer: IdContainer[E#Id],
-    tokenAccessor: TokenAccessor
+    tokenAccessor: TokenAccessor,
+    env: Environment
 ) {
 
     /**
@@ -68,6 +70,11 @@ class AsyncAuth[E <: Env] @Inject() (
         }
     }
 
-    private def extractToken(request: RequestHeader): Option[AuthenticityToken] = tokenAccessor.extract(request)
+    private def extractToken(request: RequestHeader): Option[AuthenticityToken] = {
+        if(env.mode == play.api.Mode.Test)
+            request.headers.get("SENTRY_TEST_TOKEN")
+        else
+            tokenAccessor.extract(request)
+    }
 
 }

--- a/core/src/main/scala/com/jaroop/play/sentry/AuthenticatedActionBuilder.scala
+++ b/core/src/main/scala/com/jaroop/play/sentry/AuthenticatedActionBuilder.scala
@@ -52,7 +52,7 @@ class AuthenticatedActionBuilder[E <: Env] @Inject() (
      *          for the given authority key. If the user is not authorized, then they receive the `Result` as configured
      *          by the available [[AuthConfig]].
      */
-    final def withAuthorization(authority: E#Authority): ActionBuilder[AuthRequest[?, E#User]] = {
+    def withAuthorization(authority: E#Authority): ActionBuilder[AuthRequest[?, E#User]] = {
         new ActionBuilder[AuthRequest[?, E#User]] {
             override protected implicit def executionContext = self.executionContext
             override protected def composeParser[A](bodyParser: BodyParser[A]): BodyParser[A] = self.composeParser(bodyParser)

--- a/core/src/test/scala/com/jaroop/play/sentry/AsyncAuthSpec.scala
+++ b/core/src/test/scala/com/jaroop/play/sentry/AsyncAuthSpec.scala
@@ -5,6 +5,7 @@ import org.mockito.Matchers._
 import org.specs2.concurrent._
 import org.specs2.mock._
 import org.specs2.mutable._
+import play.api.Environment
 import play.api.mvc.{ RequestHeader, Result, Results }
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
@@ -15,7 +16,7 @@ class AsyncAuthSpec(implicit ee: ExecutionEnv) extends Specification with Mockit
         config: AuthConfig[TestEnv],
         idContainer: IdContainer[Long],
         tokenAccessor: TokenAccessor
-    ) extends AsyncAuth[TestEnv](config, idContainer, tokenAccessor) {
+    ) extends AsyncAuth[TestEnv](config, idContainer, tokenAccessor, mock[Environment]) {
         override def restoreUser(implicit request: RequestHeader, ec: ExecutionContext): Future[(Option[User], ResultUpdater)] =
             Future.successful((Option(User.test), identity _))
     }
@@ -27,7 +28,7 @@ class AsyncAuthSpec(implicit ee: ExecutionEnv) extends Specification with Mockit
             val config = mock[AuthConfig[TestEnv]]
             val idContainer = mock[IdContainer[Long]]
             val tokenAccessor = mock[TokenAccessor]
-            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor)
+            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor, mock[Environment])
             implicit val request = mock[RequestHeader]
             val token = "secrettoken"
             val userId = 1L
@@ -45,7 +46,7 @@ class AsyncAuthSpec(implicit ee: ExecutionEnv) extends Specification with Mockit
             val config = mock[AuthConfig[TestEnv]]
             val idContainer = mock[IdContainer[Long]]
             val tokenAccessor = mock[TokenAccessor]
-            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor)
+            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor, mock[Environment])
             implicit val request = mock[RequestHeader]
             val token = "secrettoken"
             val userId = 1L
@@ -63,7 +64,7 @@ class AsyncAuthSpec(implicit ee: ExecutionEnv) extends Specification with Mockit
             val config = mock[AuthConfig[TestEnv]]
             val idContainer = mock[IdContainer[Long]]
             val tokenAccessor = mock[TokenAccessor]
-            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor)
+            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor, mock[Environment])
             implicit val request = mock[RequestHeader]
             val token = "secrettoken"
             val userId = 1L
@@ -81,7 +82,7 @@ class AsyncAuthSpec(implicit ee: ExecutionEnv) extends Specification with Mockit
             val config = mock[AuthConfig[TestEnv]]
             val idContainer = mock[IdContainer[Long]]
             val tokenAccessor = mock[TokenAccessor]
-            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor)
+            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor, mock[Environment])
             implicit val request = mock[RequestHeader]
             val token = "secrettoken"
             val userId = 1L
@@ -99,7 +100,7 @@ class AsyncAuthSpec(implicit ee: ExecutionEnv) extends Specification with Mockit
             val config = mock[AuthConfig[TestEnv]]
             val idContainer = mock[IdContainer[Long]]
             val tokenAccessor = mock[TokenAccessor]
-            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor)
+            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor, mock[Environment])
             implicit val request = mock[RequestHeader]
             val token = "secrettoken"
             val userId = 1L
@@ -117,7 +118,7 @@ class AsyncAuthSpec(implicit ee: ExecutionEnv) extends Specification with Mockit
             val config = mock[AuthConfig[TestEnv]]
             val idContainer = mock[IdContainer[Long]]
             val tokenAccessor = mock[TokenAccessor]
-            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor)
+            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor, mock[Environment])
             implicit val request = mock[RequestHeader]
             val token = "secrettoken"
             val userId = 1L
@@ -135,7 +136,7 @@ class AsyncAuthSpec(implicit ee: ExecutionEnv) extends Specification with Mockit
             val config = mock[AuthConfig[TestEnv]]
             val idContainer = mock[IdContainer[Long]]
             val tokenAccessor = mock[TokenAccessor]
-            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor)
+            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor, mock[Environment])
             implicit val request = mock[RequestHeader]
             val token = "secrettoken"
             val userId = 1L
@@ -195,7 +196,7 @@ class AsyncAuthSpec(implicit ee: ExecutionEnv) extends Specification with Mockit
             val idContainer = mock[IdContainer[Long]]
             val tokenAccessor = mock[TokenAccessor]
 
-            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor) {
+            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor, mock[Environment]) {
                 override def restoreUser(implicit request: RequestHeader, ec: ExecutionContext): Future[(Option[User], ResultUpdater)] =
                     Future.successful((Option.empty[User], identity _))
             }
@@ -212,7 +213,7 @@ class AsyncAuthSpec(implicit ee: ExecutionEnv) extends Specification with Mockit
             val config = mock[AuthConfig[TestEnv]]
             val idContainer = mock[IdContainer[Long]]
             val tokenAccessor = mock[TokenAccessor]
-            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor) {
+            val auth = new AsyncAuth[TestEnv](config, idContainer, tokenAccessor, mock[Environment]) {
                 override def restoreUser(implicit request: RequestHeader, ec: ExecutionContext): Future[(Option[User], ResultUpdater)] =
                     Future.failed(new Exception)
             }

--- a/examples/conf/application.conf
+++ b/examples/conf/application.conf
@@ -1,4 +1,4 @@
-play.crypto.secret = "changeme"
+play.http.secret.key = "changeme"
 
 play.modules {
     enabled += "modules.AuthModule"

--- a/examples/test/ExampleSpec.scala
+++ b/examples/test/ExampleSpec.scala
@@ -1,0 +1,98 @@
+package test
+
+import com.jaroop.play.sentry._
+import com.jaroop.play.sentry.test._
+import controllers._
+import models._
+import org.specs2.mock._
+import org.specs2.mutable._
+import play.api.test._, Helpers._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ExampleSpec extends Specification with Mockito {
+
+    "The Examples" should {
+
+        // Use the old withLoggedIn for tests
+        "return the index with the logged-in user printed out" in new WithApplication {
+            val user = User(Option(1L), "test@jaroop.com")
+            val request = FakeRequest(GET, "/").withLoggedIn[EnvImpl](1L)
+            val Some(result) = route(app, request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must contain(s"You are logged in as: $user")
+        }
+
+        "return the index with a message stating the user is not logged-in" in new WithApplication {
+            val request = FakeRequest(GET, "/")
+            val Some(result) = route(app, request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must contain(s"You are not logged in")
+        }
+
+        // Use mocked action builders that return a static user, instead (no application required)
+        "display the user on a page where authentication is required" in {
+            val user = User(Option(1L), "test@jaroop.com")
+            val request = FakeRequest(GET, "/priv")
+            val controller = new HomeController(
+                MockAuthenticatedActionBuilder[EnvImpl](user),
+                MockOptionalAuthenticatedActionBuilder[EnvImpl](None),
+                mock[Login[EnvImpl]],
+                mock[Logout[EnvImpl]],
+                mock[UserService]
+            )
+            val result = controller.priv(request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must contain(s"Success! You are logged in as $user")
+        }
+
+        "display the user on a page where authorization is required" in {
+            val user = User(Option(1L), "test@jaroop.com")
+            val request = FakeRequest(GET, "/priv")
+            val controller = new HomeController(
+                MockAuthenticatedActionBuilder[EnvImpl](user),
+                MockOptionalAuthenticatedActionBuilder[EnvImpl](None),
+                mock[Login[EnvImpl]],
+                mock[Logout[EnvImpl]],
+                mock[UserService]
+            )
+            val result = controller.lockedList(request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must contain(
+                s"You have the required permissions (List) to see this page, and are logged in as: $user"
+            )
+        }
+
+        "return the index with the logged-in user printed out" in new WithApplication {
+            val user = User(Option(1L), "test@jaroop.com")
+            val optionalAuthAction = MockOptionalAuthenticatedActionBuilder[EnvImpl](Option(user))
+            val request = FakeRequest(GET, "/")
+            val controller = new HomeController(
+                MockAuthenticatedActionBuilder[EnvImpl](user),
+                optionalAuthAction,
+                mock[Login[EnvImpl]],
+                mock[Logout[EnvImpl]],
+                mock[UserService]
+            )
+            val result = controller.index(request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must contain(s"You are logged in as: $user")
+        }
+
+        "return the index with a message stating the user is not logged-in" in new WithApplication {
+            val optionalAuthAction = MockOptionalAuthenticatedActionBuilder[EnvImpl](None)
+            val request = FakeRequest(GET, "/")
+            val controller = new HomeController(
+                MockAuthenticatedActionBuilder[EnvImpl](null),
+                optionalAuthAction,
+                mock[Login[EnvImpl]],
+                mock[Logout[EnvImpl]],
+                mock[UserService]
+            )
+            val result = controller.index(request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must contain(s"You are not logged in")
+        }
+
+    }
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,7 @@ resolvers ++= Seq(
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.17")
 
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "latest.release")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/sentry-test/src/main/scala/com/jaroop/play/sentry/test/MockActionBuilders.scala
+++ b/sentry-test/src/main/scala/com/jaroop/play/sentry/test/MockActionBuilders.scala
@@ -1,0 +1,35 @@
+package com.jaroop.play.sentry.test
+
+import com.jaroop.play.sentry._
+import play.api.mvc._
+import scala.concurrent.{ ExecutionContext, Future }
+
+/**
+ *  A fake [[AuthenticatedActionBuilder]] that will always invoke the given action block, and use the provided logged-in user.
+ *  [[MockAuthenticatedActionBuilder#withAuthorization]] will always authorize the user and invoke the given block, as well.
+ *
+ *  @param user The user that will be logged-in for the test.
+ */
+case class MockAuthenticatedActionBuilder[E <: Env] (val user: E#User)(implicit ec: ExecutionContext)
+    extends AuthenticatedActionBuilder[E](null, null)(ec) { self =>
+
+    override final def withAuthorization(authority: E#Authority): ActionBuilder[AuthRequest[?, E#User]] = this
+
+    override def invokeBlock[A](request: Request[A], block: AuthRequest[A, E#User] => Future[Result]): Future[Result] =
+        block(new AuthRequest(request, user))
+
+}
+
+/**
+ *  A fake [[OptionalAuthenticatedActionBuilder]] that will always invoke the given block, and will use the given
+ *  optional user within the request.
+ *
+ *  @param user The optional user that will be included in each request that invokes this action.
+ */
+case class MockOptionalAuthenticatedActionBuilder[E <: Env] (val user: Option[E#User])(implicit val rc: ExecutionContext)
+    extends OptionalAuthenticatedActionBuilder[E](null) {
+
+    override def invokeBlock[A](request: Request[A], block: OptionalAuthRequest[A, E#User] => Future[Result]) =
+        block(new OptionalAuthRequest(request, user))
+
+}

--- a/sentry-test/src/main/scala/com/jaroop/play/sentry/test/package.scala
+++ b/sentry-test/src/main/scala/com/jaroop/play/sentry/test/package.scala
@@ -1,0 +1,34 @@
+package com.jaroop.play.sentry
+
+import com.google.inject.{ AbstractModule, Injector => GuiceInjector, Key, TypeLiteral }
+import play.api.Application
+import play.api.test.FakeRequest
+import scala.concurrent.{ Await, ExecutionContext }
+import scala.concurrent.duration._
+
+/**
+ *  Provides helpers for testing controllers that user Play Sentry components.
+ */
+package object test {
+
+    implicit class FakeRequestOps[A](request: FakeRequest[A])(implicit ec: ExecutionContext, app: Application) {
+
+        /**
+         *  Adds a special header to a [[play.api.test.FakeRequest FakeRequest]] in order to allow grant a user with a specific
+         *  ID a test session. Use this method for tests that use an injected router.
+         *
+         *  @param userId The ID of the user to grant the session to.
+         *  @tparam E The environment type of your application.
+         *  @return A new [[play.api.test.FakeRequest FakeRequest]] with an authenticity token for the user included.
+         */
+        def withLoggedIn[E <: Env](userId: E#Id): FakeRequest[A] = {
+            val cache = Application.instanceCache[GuiceInjector]
+            val guiceInjector = cache(app)
+            val idContainer = guiceInjector.getInstance(Key.get(new TypeLiteral[IdContainer[E#Id]] {}))
+            val token = Await.result(idContainer.startNewSession(userId, 1.hour), 10.seconds)
+            request.withHeaders("SENTRY_TEST_TOKEN" -> token)
+        }
+
+    }
+
+}

--- a/sentry-test/src/test/scala/com/jaroop/play/sentry/test/FakeRequestOpsSpec.scala
+++ b/sentry-test/src/test/scala/com/jaroop/play/sentry/test/FakeRequestOpsSpec.scala
@@ -1,0 +1,32 @@
+package com.jaroop.play.sentry.test
+
+import com.jaroop.play.sentry._
+import org.specs2.concurrent._
+import org.specs2.mutable._
+import play.api.Mode
+import play.api.inject._
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc._
+import play.api.routing._
+import play.api.test._, Helpers._
+
+class FakeRequestOpsSpec(implicit ee: ExecutionEnv) extends Specification {
+
+    val application = new GuiceApplicationBuilder()
+        .bindings(new TestAuthModule)
+        .overrides(bind[Router].toProvider[ScalaRoutesProvider])
+        .in(Mode.Test)
+        .build
+
+    "withLoggedIn" should {
+
+        "create a test session for a user" in new WithApplication(application) {
+            val request = FakeRequest(GET, "/test").withLoggedIn[TestEnv](1L)
+            val Some(result) = route(app, request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must equalTo("You are test@example.com")
+        }
+
+    }
+
+}

--- a/sentry-test/src/test/scala/com/jaroop/play/sentry/test/Fixtures.scala
+++ b/sentry-test/src/test/scala/com/jaroop/play/sentry/test/Fixtures.scala
@@ -1,0 +1,84 @@
+package com.jaroop.play.sentry.test
+
+import com.google.inject.{ AbstractModule, TypeLiteral }
+import com.jaroop.play.sentry._
+import javax.inject.{ Inject, Provider, Singleton }
+import play.api.http.HttpConfiguration
+import play.api.inject._
+import play.api.mvc._, Results._
+import play.api.routing._
+import play.api.routing.sird._
+import scala.concurrent._, duration._
+import scala.reflect.{ ClassTag, classTag }
+
+trait TestEnv extends Env {
+    type Id = Long
+    type User = Account
+    type Authority = Role
+}
+
+case class Account(id: Option[Long], email: String)
+
+object Account {
+
+    val test = Account(Option(1L), "test@example.com")
+
+}
+
+sealed trait Role
+case object Admin extends Role
+case object Manager extends Role
+case object Employee extends Role
+
+class TestAuthModule extends AbstractModule {
+
+    def configure(): Unit = {
+        bind(new TypeLiteral[AuthConfig[TestEnv]]() {}).to(classOf[TestAuthConfig])
+        bind(classOf[TokenAccessor]).to(classOf[CookieTokenAccessor])
+        bind(new TypeLiteral[IdContainer[Long]] {}).to(new TypeLiteral[CacheIdContainer[Long]] {})
+        bind(new TypeLiteral[ClassTag[Long]] {}).toInstance(classTag[Long])
+    }
+
+}
+
+class TestController @Inject() (action: AuthenticatedActionBuilder[TestEnv]) extends Controller {
+    def test = action { implicit request =>
+        Results.Ok(s"You are ${request.user.email}")
+    }
+}
+
+class TestRouter @Inject() (controller: TestController) extends SimpleRouter {
+    def routes = {
+        case GET(p"/test") => controller.test
+    }
+}
+
+@Singleton
+class ScalaRoutesProvider @Inject()(testRouter: TestRouter, httpConfig: HttpConfiguration) extends Provider[Router] {
+    lazy val get = testRouter.withPrefix(httpConfig.context)
+}
+
+class TestAuthConfig extends AuthConfig[TestEnv] {
+
+    def sessionTimeout = 120.seconds
+
+    def resolveUser(id: Long)(implicit context: ExecutionContext): Future[Option[Account]] =
+        Future.successful(Option(Account.test))
+
+    def loginSucceeded(request: RequestHeader)(implicit context: ExecutionContext): Future[Result] =
+        Future.successful(Redirect("/"))
+
+    def logoutSucceeded(request: RequestHeader)(implicit context: ExecutionContext): Future[Result] =
+        Future.successful(Redirect("/"))
+
+    def authenticationFailed(request: RequestHeader)(implicit context: ExecutionContext): Future[Result] =
+        Future.successful(Forbidden("You are not logged in."))
+
+    def authorizationFailed(request: RequestHeader, user: Account, authority: Option[Role])
+        (implicit context: ExecutionContext): Future[Result] =
+        Future.successful(Forbidden("Unauthorized."))
+
+    def authorize(user: Account, authority: Role)(implicit context: ExecutionContext): Future[Boolean] =
+        Future.successful(true)
+
+}

--- a/sentry-test/src/test/scala/com/jaroop/play/sentry/test/MockActionBuilderSpec.scala
+++ b/sentry-test/src/test/scala/com/jaroop/play/sentry/test/MockActionBuilderSpec.scala
@@ -1,0 +1,86 @@
+package com.jaroop.play.sentry.test
+
+import com.jaroop.play.sentry._
+import org.specs2.concurrent._
+import org.specs2.mock._
+import org.specs2.mutable._
+import play.api.Application
+import play.api.libs.json._
+import play.api.mvc._
+import play.api.test._, Helpers._
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class MockActionBuilderSpec(implicit ee: ExecutionEnv) extends Specification {
+
+    "The mock action builders" should {
+
+        "invoke a simple action block" in {
+            val builder = MockAuthenticatedActionBuilder[TestEnv](Account.test)
+            val action = builder { request =>
+                Results.Ok(s"Email: ${request.user.email}")
+            }
+            val request = FakeRequest()
+            val result = action(request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must equalTo("Email: test@example.com")
+        }
+
+        "invoke an action block asynchronously" in {
+            val builder = MockAuthenticatedActionBuilder[TestEnv](Account.test)
+            val action = builder.async { request =>
+                Future.successful(Results.Ok(s"Email: ${request.user.email}"))
+            }
+            val request = FakeRequest()
+            val result = action(request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must equalTo("Email: test@example.com")
+        }
+
+        "invoke an action with a json body parser" in new WithApplication {
+            val builder = MockAuthenticatedActionBuilder[TestEnv](Account.test)
+            val action = builder(BodyParsers.parse.json) { request =>
+                Results.Ok(s"Email: ${request.user.email}")
+            }
+            val request = FakeRequest().withBody(Json.obj("key" -> "value"))
+            val result = action(request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must equalTo("Email: test@example.com")
+        }
+
+        "invoke a simple action block with an optional user" in {
+            val builder = MockOptionalAuthenticatedActionBuilder[TestEnv](Option(Account.test))
+            val action = builder { request =>
+                Results.Ok(s"""Email: ${request.user.map(_.email).getOrElse("n/a")}""")
+            }
+            val request = FakeRequest()
+            val result = action(request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must equalTo("Email: test@example.com")
+        }
+
+        "invoke a simple action block asynchronously" in {
+            val builder = MockOptionalAuthenticatedActionBuilder[TestEnv](Option(Account.test))
+            val action = builder.async { request =>
+                Future.successful(Results.Ok(s"""Email: ${request.user.map(_.email).getOrElse("n/a")}"""))
+            }
+            val request = FakeRequest()
+            val result = action(request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must equalTo("Email: test@example.com")
+        }
+
+        "invoke an action with a json body parser" in new WithApplication {
+            val builder = MockOptionalAuthenticatedActionBuilder[TestEnv](Option(Account.test))
+            val action = builder(BodyParsers.parse.json) { request =>
+                Results.Ok(s"""Email: ${request.user.map(_.email).getOrElse("n/a")}""")
+            }
+            val request = FakeRequest().withBody(Json.obj("key" -> "value"))
+            val result = action(request)
+            status(result) must equalTo(OK)
+            contentAsString(result) must equalTo("Email: test@example.com")
+        }
+
+    }
+
+}


### PR DESCRIPTION
This is approximately the same as #13, but with a few minor differences for Play 2.5.x. "play-test" in 2.5.x isn't binary compatible with specs2 3.9.5, so that had to be rolled back for projects that needed it.